### PR TITLE
Add basic coloring using Crayons.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Abel Soares Siqueira <abel.s.siqueira@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/src/Jet.jl
+++ b/src/Jet.jl
@@ -4,6 +4,7 @@ using DataStructures
 using JSON
 using Markdown
 using ReplMaker
+using Crayons
 
 function __init__()
   global data = JSON.parsefile(joinpath(@__DIR__, "..", "data.json"), dicttype=OrderedDict)

--- a/src/format.jl
+++ b/src/format.jl
@@ -1,3 +1,8 @@
+const title_crayon  = Crayon(foreground = :light_cyan, bold = true, underline = true)
+const desc_crayon = Crayon(foreground = :light_cyan, bold = true, underline = false)
+const cmd_desc_crayon = Crayon(foreground = :green, bold = false)
+const cmd_crayon = Crayon(foreground = :blue)
+
 """
     format(output, print)
 
@@ -10,12 +15,12 @@ function format(output, should_print)
     if entry["kind"] == "header"
       s *= entry["package"] * "\n\n" * entry["description"] * "\n\n"
       if should_print
-        print(Crayon(foreground = :light_cyan, bold = true, underline = true),entry["package"] * "\n\n",Crayon(foreground = :light_cyan, bold = true, underline = false), entry["description"] * "\n\n")
+        print(title_crayon, entry["package"] * "\n\n", desc_crayon, entry["description"] * "\n\n")
       end
     else
       s *= "- " * entry["description"] * "\n  `" * entry["command"] * "`\n\n"
       if should_print
-        print(Crayon(foreground = :green, bold = false),"- " * entry["description"] * "\n " ,Crayon(foreground = :blue), "`"*entry["command"] , "`\n\n")
+        print(cmd_desc_crayon, "- " * entry["description"] * "\n ", cmd_crayon, "`"*entry["command"], "`\n\n")
       end
     end
   end

--- a/src/format.jl
+++ b/src/format.jl
@@ -1,7 +1,7 @@
-const title_crayon  = Crayon(foreground = :light_cyan, bold = true, underline = true)
-const desc_crayon = Crayon(foreground = :light_cyan, bold = true, underline = false)
+const title_crayon    = Crayon(foreground = :light_cyan, bold = true, underline = true)
+const desc_crayon     = Crayon(foreground = :light_cyan, bold = true, underline = false)
 const cmd_desc_crayon = Crayon(foreground = :green, bold = false)
-const cmd_crayon = Crayon(foreground = :blue)
+const cmd_crayon      = Crayon(foreground = :blue)
 
 """
     format(output, print)

--- a/src/format.jl
+++ b/src/format.jl
@@ -9,13 +9,17 @@ function format(output, should_print)
   for entry in output
     if entry["kind"] == "header"
       s *= entry["package"] * "\n\n" * entry["description"] * "\n\n"
+      if should_print
+        print(Crayon(foreground = :light_cyan, bold = true, underline = true),entry["package"] * "\n\n",Crayon(foreground = :light_cyan, bold = true, underline = false), entry["description"] * "\n\n")
+      end
     else
       s *= "- " * entry["description"] * "\n  `" * entry["command"] * "`\n\n"
+      if should_print
+        print(Crayon(foreground = :green, bold = false),"- " * entry["description"] * "\n " ,Crayon(foreground = :blue), "`"*entry["command"] , "`\n\n")
+      end
     end
   end
-  if should_print
-    print(s)
-  else
+  if !should_print
     s
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using DataStructures
 using Jet
 using JSON
-using Crayons
 using Test
 
 include("output.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using DataStructures
 using Jet
 using JSON
+using Crayons
 using Test
 
 include("output.jl")


### PR DESCRIPTION
This is just an attempt to adding colors to the output using crayons.jl . This can be optimized a lot.
Syntax highlighting for code snippets is not added yet.
This just adds color and underline to the text and nothing more. No line breaks are changes and the bare-bones text remains basically the same.
 
![2020-10-14-225200_1920x1080_scrot_000](https://user-images.githubusercontent.com/30381591/96023567-4283ec00-0e70-11eb-9254-8b6ad0ce02da.png)
